### PR TITLE
Use --color=never to suppress any control characters.

### DIFF
--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -68,7 +68,7 @@ def main():
             msglines.append(line)
 
     logname = os.popen('git config ' + CONFIG).read().strip() or DEFAULT
-    diff = os.popen('git diff --staged -- ' + logname).readlines()
+    diff = os.popen('git diff --color=never --staged -- ' + logname).readlines()
     log = []
     for line in diff:
         if line.startswith('+') and not line.startswith('+++'):


### PR DESCRIPTION
Without this fix and activated color a leading '+' is not detected in changelog lines.
